### PR TITLE
Login front

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 jobs:

--- a/.github/workflows/rendering_tests.yml
+++ b/.github/workflows/rendering_tests.yml
@@ -1,0 +1,20 @@
+name: Rendering tests
+on: 
+    pull_request: 
+        branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with: 
+        node-version: 18
+    - name: Install frontend dependencies 
+      run: npm ci
+      working-directory: oyster_front
+    - name: Run rendering tests in emulated environment
+      run: npm test
+      working-directory: oyster_front
+    env:
+        VITE_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}

--- a/e2e/tests/mobile/userFrontEnd.test.ts
+++ b/e2e/tests/mobile/userFrontEnd.test.ts
@@ -10,5 +10,21 @@ describe("user front-end", () => {
       const header = page.getByTestId("header-logo");
       await expect(header).toBeVisible();
     });
+    describe("/login", async () => {
+      beforeEach(async ({ page }) => {
+        await page.goto("login");
+      });
+      test("elements are visible", async ({ page }) => {
+        const header = page.getByTestId("login-header");
+        const emailInput = page.getByTestId("login-email-input");
+        const passwordInput = page.getByTestId("login-password-input");
+        const loginButton = page.getByTestId("login-button");
+
+        await expect(header).toBeVisible();
+        await expect(emailInput).toBeVisible();
+        await expect(passwordInput).toBeVisible();
+        await expect(loginButton).toBeVisible();
+      });
+    });
   });
 });

--- a/oyster_front/__tests__/Header.test.tsx
+++ b/oyster_front/__tests__/Header.test.tsx
@@ -1,11 +1,11 @@
 import Header from "../src/components/Header";
 import { cleanup, screen } from "@testing-library/react";
-import renderWithTheme from "./utils/renderWithTheme";
+import { renderWithThemeAndProviders } from "./utils/renderWithTheme";
 
 describe("<Header />", () => {
   const header = <Header />;
   beforeEach(() => {
-    renderWithTheme(header);
+    renderWithThemeAndProviders(header);
   });
   afterEach(() => {
     cleanup();
@@ -15,7 +15,7 @@ describe("<Header />", () => {
     const header = screen.getByTestId("header");
     const profileButton = screen.getByTestId("profile-button");
     const menuButton = screen.getByTestId("menu-button");
-    
+
     expect(header).toBeVisible();
     expect(profileButton).toBeVisible();
     expect(menuButton).toBeVisible();

--- a/oyster_front/__tests__/Login.test.tsx
+++ b/oyster_front/__tests__/Login.test.tsx
@@ -1,15 +1,20 @@
 import Login from "../src/routes/Login";
 import { cleanup, screen } from "@testing-library/react";
-import renderWithTheme from "./utils/renderWithTheme";
+import { renderWithThemeAndProviders } from "./utils/renderWithTheme";
+import * as userSlice from "../src/store/userSlice";
 
 describe("<Login />", () => {
   const login = <Login />;
-  beforeEach(() => {
-    renderWithTheme(login);
+
+  beforeEach(async () => {
+    renderWithThemeAndProviders(login);
   });
+
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
+
   test("should render header", () => {
     const header = screen.getByTestId("login-header");
     expect(header).toBeVisible();
@@ -35,5 +40,11 @@ describe("<Login />", () => {
 
     expect(loginButton).toBeVisible();
     expect(loginButton).toHaveTextContent("Login");
+  });
+  test("should call getUserFromLocalStorage on render", () => {
+    const spy = vi.spyOn(userSlice, "getUserFromLocalStorage");
+    renderWithThemeAndProviders(login);
+
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/oyster_front/__tests__/Login.test.tsx
+++ b/oyster_front/__tests__/Login.test.tsx
@@ -25,10 +25,15 @@ describe("<Login />", () => {
   });
   test("should render password input", () => {
     const passwordInput = screen.getByTestId("login-password-input");
-    const passwordLabel = screen.getByTestId("Password");
+    const passwordLabel = screen.getByLabelText("Password");
 
     expect(passwordInput).toBeVisible();
     expect(passwordLabel).toBeVisible();
-    expect(passwordLabel).toHaveRole("textbox");
+  });
+  test("should render login button", () => {
+    const loginButton = screen.getByRole("button");
+
+    expect(loginButton).toBeVisible();
+    expect(loginButton).toHaveTextContent("Login");
   });
 });

--- a/oyster_front/__tests__/Login.test.tsx
+++ b/oyster_front/__tests__/Login.test.tsx
@@ -13,13 +13,22 @@ describe("<Login />", () => {
   test("should render header", () => {
     const header = screen.getByTestId("login-header");
     expect(header).toBeVisible();
+    expect(header).toHaveTextContent("Login");
   });
   test("should render email input", () => {
     const emailInput = screen.getByTestId("login-email-input");
+    const emailLabel = screen.getByLabelText("Email");
+
     expect(emailInput).toBeVisible();
+    expect(emailLabel).toBeVisible();
+    expect(emailLabel).toHaveRole("textbox");
   });
   test("should render password input", () => {
     const passwordInput = screen.getByTestId("login-password-input");
+    const passwordLabel = screen.getByTestId("Password");
+
     expect(passwordInput).toBeVisible();
+    expect(passwordLabel).toBeVisible();
+    expect(passwordLabel).toHaveRole("textbox");
   });
 });

--- a/oyster_front/__tests__/Login.test.tsx
+++ b/oyster_front/__tests__/Login.test.tsx
@@ -1,0 +1,25 @@
+import Login from "../src/routes/Login";
+import { cleanup, screen } from "@testing-library/react";
+import renderWithTheme from "./utils/renderWithTheme";
+
+describe("<Login />", () => {
+  const login = <Login />;
+  beforeEach(() => {
+    renderWithTheme(login);
+  });
+  afterEach(() => {
+    cleanup();
+  });
+  test("should render header", () => {
+    const header = screen.getByTestId("login-header");
+    expect(header).toBeVisible();
+  });
+  test("should render email input", () => {
+    const emailInput = screen.getByTestId("login-email-input");
+    expect(emailInput).toBeVisible();
+  });
+  test("should render password input", () => {
+    const passwordInput = screen.getByTestId("login-password-input");
+    expect(passwordInput).toBeVisible();
+  });
+});

--- a/oyster_front/__tests__/utils/renderWithTheme.tsx
+++ b/oyster_front/__tests__/utils/renderWithTheme.tsx
@@ -3,14 +3,21 @@ import { render, RenderResult } from "@testing-library/react"; // RenderResult i
 import { ThemeProvider } from "@mui/material/styles";
 import { CssBaseline } from "@mui/material";
 import theme from "../../src/utils/theme/theme";
+import { Provider } from "react-redux";
+import store from "../../src/store/store";
+import { BrowserRouter as Router } from "react-router-dom";
 
 // Create virtual DOM using MUI theme provider and the theme currently in use
 const renderWithTheme = (ui: ReactNode): RenderResult => {
   return render(
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      {ui}
-    </ThemeProvider>
+    <Router>
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          {ui}
+        </ThemeProvider>
+      </Provider>
+    </Router>
   );
 };
 

--- a/oyster_front/__tests__/utils/renderWithTheme.tsx
+++ b/oyster_front/__tests__/utils/renderWithTheme.tsx
@@ -4,11 +4,11 @@ import { ThemeProvider } from "@mui/material/styles";
 import { CssBaseline } from "@mui/material";
 import theme from "../../src/utils/theme/theme";
 import { Provider } from "react-redux";
-import store from "../../src/store/store";
 import { BrowserRouter as Router } from "react-router-dom";
+import store from "../../src/store/store";
 
-// Create virtual DOM using MUI theme provider and the theme currently in use
-const renderWithTheme = (ui: ReactNode): RenderResult => {
+// Create virtual DOM using React Router, Redux store Provider, MUI theme provider and the theme currently in use
+const renderWithThemeAndProviders = (ui: ReactNode): RenderResult => {
   return render(
     <Router>
       <Provider store={store}>
@@ -21,4 +21,4 @@ const renderWithTheme = (ui: ReactNode): RenderResult => {
   );
 };
 
-export default renderWithTheme;
+export { renderWithThemeAndProviders };

--- a/oyster_front/src/App.tsx
+++ b/oyster_front/src/App.tsx
@@ -3,14 +3,18 @@ import Root from "./routes/Root";
 import Login from "./routes/Login";
 import Profile from "./routes/Profile";
 import Register from "./routes/Register";
+import ProtectedRoute from "./routes/ProtectedRoute";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Root />}>
-        <Route path="/login" element={<Login />} />
-        <Route path="/profile/:id" element={<Profile />} />
-        <Route path="/register" element={<Register />}/>
+        <Route path="login" element={<Login />} />
+        <Route
+          path="profile/:id"
+          element={<ProtectedRoute component={Profile} />}
+        />
+        <Route path="register" element={<Register />} />
       </Route>
     </Routes>
   );

--- a/oyster_front/src/routes/Login.tsx
+++ b/oyster_front/src/routes/Login.tsx
@@ -83,17 +83,19 @@ const Login = () => {
         component={"form"}
         onSubmit={handleSubmit}
       >
-        <Typography variant="h2">Login</Typography>
+        <Typography variant="h2" data-testid="login-header">Login</Typography>
         <TextField
           label="Email"
           onChange={(e) => setEmail(e.target.value)}
           value={email}
+          inputProps={{"data-testid":"login-email-input"}}
         />
         <TextField
           label="Password"
           type="password"
           onChange={(e) => setPassword(e.target.value)}
           value={password}
+          inputProps={{"data-testid":"login-password-input"}}
         />
         <Button type="submit">Login</Button>
       </Box>

--- a/oyster_front/src/routes/Login.tsx
+++ b/oyster_front/src/routes/Login.tsx
@@ -9,17 +9,28 @@ import { loginWithEmailAndPassword } from "../services/loginService";
 import AlertHandler from "../components/AlertHandler";
 import { useDispatch, useSelector } from "react-redux";
 import { setAlert } from "../store/alertSlice";
-import { RootState } from "../utils/types";
 import { useNavigate } from "react-router-dom";
-import { setUser } from "../store/userSlice";
+import { RootState, AppDispatch } from "../store/store";
+import { getUserFromLocalStorage, setUser } from "../store/userSlice";
+import { UserObject } from "../utils/types";
 
 const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const user = useSelector((state: RootState) => state.user);
   const navigate = useNavigate();
+
+  // Check if user object is in local storage and dispatch it to the store
+  // If user object exists in store then redirect to profile page
+  useEffect(() => {
+    if (user === null) {
+      dispatch(getUserFromLocalStorage());
+    } else if (user) {
+      navigate(`../profile/${user.uid}`, { relative: "path" });
+    }
+  }, [user, dispatch, navigate]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -42,7 +53,7 @@ const Login = () => {
 
       // If custom token sign-in was succesful, store signed in user data and custom token in local storage
       if (loginResult.user) {
-        const currentUser = { ...response };
+        const currentUser: UserObject = { ...response };
         localStorage.setItem("loggedUser", JSON.stringify(currentUser));
         dispatch(setUser(currentUser));
       } else {
@@ -55,17 +66,6 @@ const Login = () => {
       setPassword("");
     }
   };
-
-  // Check if user is authenticated in Redux or local storage and redirect to user's profile page if uid exists
-  useEffect(() => {
-    const storedUser = localStorage.getItem("loggedUser");
-    if (storedUser) {
-      const userObject = JSON.parse(storedUser);
-      navigate(`../profile/${userObject.uid}`, { relative: "path" });
-    } else if (user.uid) {
-      navigate(`../profile/${user.uid}`, { relative: "path" });
-    }
-  }, [user]);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/oyster_front/src/routes/Login.tsx
+++ b/oyster_front/src/routes/Login.tsx
@@ -83,21 +83,25 @@ const Login = () => {
         component={"form"}
         onSubmit={handleSubmit}
       >
-        <Typography variant="h2" data-testid="login-header">Login</Typography>
+        <Typography variant="h2" data-testid="login-header">
+          Login
+        </Typography>
         <TextField
           label="Email"
           onChange={(e) => setEmail(e.target.value)}
           value={email}
-          inputProps={{"data-testid":"login-email-input"}}
+          inputProps={{ "data-testid": "login-email-input" }}
         />
         <TextField
           label="Password"
           type="password"
           onChange={(e) => setPassword(e.target.value)}
           value={password}
-          inputProps={{"data-testid":"login-password-input"}}
+          inputProps={{ "data-testid": "login-password-input" }}
         />
-        <Button type="submit">Login</Button>
+        <Button type="submit" data-testid="login-button">
+          Login
+        </Button>
       </Box>
     </Box>
   );

--- a/oyster_front/src/routes/Login.tsx
+++ b/oyster_front/src/routes/Login.tsx
@@ -2,19 +2,24 @@ import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { signInWithCustomToken } from "firebase/auth";
 import { auth } from "../services/firebaseAuthentication";
 import { loginWithEmailAndPassword } from "../services/loginService";
 import AlertHandler from "../components/AlertHandler";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { setAlert } from "../store/alertSlice";
+import { RootState } from "../utils/types";
+import { useNavigate } from "react-router-dom";
+import { setUser } from "../store/userSlice";
 
 const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
   const dispatch = useDispatch();
+  const user = useSelector((state: RootState) => state.user);
+  const navigate = useNavigate();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -39,6 +44,7 @@ const Login = () => {
       if (loginResult.user) {
         const currentUser = { ...response };
         localStorage.setItem("loggedUser", JSON.stringify(currentUser));
+        dispatch(setUser(currentUser));
       } else {
         throw new Error("Custom token sign-in failed");
       }
@@ -49,6 +55,17 @@ const Login = () => {
       setPassword("");
     }
   };
+
+  // Check if user is authenticated in Redux or local storage and redirect to user's profile page if uid exists
+  useEffect(() => {
+    const storedUser = localStorage.getItem("loggedUser");
+    if (storedUser) {
+      const userObject = JSON.parse(storedUser);
+      navigate(`../profile/${userObject.uid}`, { relative: "path" });
+    } else if (user.uid) {
+      navigate(`../profile/${user.uid}`, { relative: "path" });
+    }
+  }, [user]);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/oyster_front/src/routes/ProtectedRoute.tsx
+++ b/oyster_front/src/routes/ProtectedRoute.tsx
@@ -1,8 +1,7 @@
-import { FC } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState, AppDispatch } from "../store/store";
 import { Navigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, FC } from "react";
 import { getUserFromLocalStorage } from "../store/userSlice";
 
 interface ProtectedRouteProps {

--- a/oyster_front/src/routes/ProtectedRoute.tsx
+++ b/oyster_front/src/routes/ProtectedRoute.tsx
@@ -1,7 +1,9 @@
 import { FC } from "react";
-import { useSelector } from "react-redux";
-import { RootState } from "../utils/types";
+import { useSelector, useDispatch } from "react-redux";
+import { RootState, AppDispatch } from "../store/store";
 import { Navigate } from "react-router-dom";
+import { useEffect } from "react";
+import { getUserFromLocalStorage } from "../store/userSlice";
 
 interface ProtectedRouteProps {
   component: FC;
@@ -9,13 +11,15 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute = ({ component: Component }: ProtectedRouteProps) => {
   const user = useSelector((state: RootState) => state.user);
-  const localStorageUserString = localStorage.getItem("loggedUser");
-  let localStorageUser;
-  if (localStorageUserString) {
-    localStorageUser = JSON.parse(localStorageUserString);
-  }
+  const dispatch = useDispatch<AppDispatch>();
 
-  if (user?.uid || localStorageUser) {
+  useEffect(() => {
+    if (user === null) {
+      dispatch(getUserFromLocalStorage());
+    }
+  }, [user]);
+
+  if (user !== null) {
     return <Component />;
   } else {
     return <Navigate to="/login" replace />;

--- a/oyster_front/src/routes/ProtectedRoute.tsx
+++ b/oyster_front/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,25 @@
+import { FC } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../utils/types";
+import { Navigate } from "react-router-dom";
+
+interface ProtectedRouteProps {
+  component: FC;
+}
+
+const ProtectedRoute = ({ component: Component }: ProtectedRouteProps) => {
+  const user = useSelector((state: RootState) => state.user);
+  const localStorageUserString = localStorage.getItem("loggedUser");
+  let localStorageUser;
+  if (localStorageUserString) {
+    localStorageUser = JSON.parse(localStorageUserString);
+  }
+
+  if (user?.uid || localStorageUser) {
+    return <Component />;
+  } else {
+    return <Navigate to="/login" replace />;
+  }
+};
+
+export default ProtectedRoute;

--- a/oyster_front/src/services/firebaseAuthentication.ts
+++ b/oyster_front/src/services/firebaseAuthentication.ts
@@ -17,7 +17,7 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth();
 
 // Use emulators if using development environment
-if (process.env.NODE_ENV === "development") {
+if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
   connectAuthEmulator(auth, "http://localhost:9099");
 }
 

--- a/oyster_front/src/store/store.ts
+++ b/oyster_front/src/store/store.ts
@@ -9,4 +9,8 @@ const store = configureStore({
   },
 });
 
+// Types of the store dispatch actions
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;
+
 export default store;

--- a/oyster_front/src/store/store.ts
+++ b/oyster_front/src/store/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import alertReducer from "./alertSlice";
+import userReducer from "./userSlice";
 
 const store = configureStore({
-    reducer: {
-        alert: alertReducer
-    }
-})
+  reducer: {
+    alert: alertReducer,
+    user: userReducer,
+  },
+});
 
 export default store;

--- a/oyster_front/src/store/userSlice.ts
+++ b/oyster_front/src/store/userSlice.ts
@@ -1,14 +1,25 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, Dispatch } from "@reduxjs/toolkit";
+import { UserState, UserObject } from "../utils/types";
+
+// State is either UserObject or null
 
 const userSlice = createSlice({
   name: "user",
-  initialState: {},
+  initialState: null as UserState,
   reducers: {
     setUser: (state, action) => {
       return action.payload;
     },
   },
 });
+
+export const getUserFromLocalStorage = () => (dispatch: Dispatch) => {
+  const userJSONString = localStorage.getItem("loggedUser");
+  if (userJSONString) {
+    const userObject: UserObject = JSON.parse(userJSONString);
+    dispatch(setUser(userObject));
+  }
+};
 
 export const { setUser } = userSlice.actions;
 export default userSlice.reducer;

--- a/oyster_front/src/store/userSlice.ts
+++ b/oyster_front/src/store/userSlice.ts
@@ -1,0 +1,14 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const userSlice = createSlice({
+  name: "user",
+  initialState: {},
+  reducers: {
+    setUser: (state, action) => {
+      return action.payload;
+    },
+  },
+});
+
+export const { setUser } = userSlice.actions;
+export default userSlice.reducer;

--- a/oyster_front/src/utils/types.d.ts
+++ b/oyster_front/src/utils/types.d.ts
@@ -12,8 +12,15 @@ interface AlertHandlerState {
   isVisible: boolean;
 }
 
-interface AlertHandlerStateSelector {
+
+interface RootState {
   alert: AlertHandlerState;
+  user?: {
+    uid: string;
+    username: string;
+    customToken: string;
+    email:string;
+  }
 }
 
-export { NewUserObject, AlertHandlerState, AlertHandlerStateSelector };
+export { NewUserObject, AlertHandlerState, RootState };

--- a/oyster_front/src/utils/types.d.ts
+++ b/oyster_front/src/utils/types.d.ts
@@ -6,21 +6,20 @@ interface NewUserObject {
   password: string;
 }
 
+// Used with Redux state
+interface UserObject {
+  uid: string;
+  username: string;
+  email: string;
+  customToken: string;
+}
+
+type UserState = UserObject | null
+
 interface AlertHandlerState {
   severity: AlertColor;
   message: string;
   isVisible: boolean;
 }
 
-
-interface RootState {
-  alert: AlertHandlerState;
-  user?: {
-    uid: string;
-    username: string;
-    customToken: string;
-    email:string;
-  }
-}
-
-export { NewUserObject, AlertHandlerState, RootState };
+export { NewUserObject, UserObject, AlertHandlerState, UserState };

--- a/tuntikirjanpito.md
+++ b/tuntikirjanpito.md
@@ -58,5 +58,6 @@
 | 14.8. | 1 | Refaktoroi käyttäjän poistava funktio `deleteById()` poistamaan myös käyttäjän tiedot Firebase Authentication kannasta, jos käyttäjän UID löytyy. |
 |    | **1**   | | 
 | 15.8. | 2 | Tee `ProtectedRoute.tsx` kirjautumattomien käyttäjien näkymän hallintaan. Säädä `Login.tsx` siirtämään käyttäjä omalle profiilisivulleen mikäli salasana ja sähköposti olivat oikein. |
-|    | **2** |   | 
+|    | 2 | Tee thunk funktio joka hakee tilan local storagesta ja siirtää tilan Redux storeen. Päivitä käyttäjän tilaan tarvittava interface `UserObject` ja tyyppi `UserState`. Refaktoroi `Login.tsx` käyttäjäntilan haku `useEffect()` hookilla. | 
+|    | **4** |   | 
 | yht   | **67**   | | 

--- a/tuntikirjanpito.md
+++ b/tuntikirjanpito.md
@@ -57,4 +57,6 @@
 |    | **7**   | | 
 | 14.8. | 1 | Refaktoroi käyttäjän poistava funktio `deleteById()` poistamaan myös käyttäjän tiedot Firebase Authentication kannasta, jos käyttäjän UID löytyy. |
 |    | **1**   | | 
+| 15.8. | 2 | Tee `ProtectedRoute.tsx` kirjautumattomien käyttäjien näkymän hallintaan. Säädä `Login.tsx` siirtämään käyttäjä omalle profiilisivulleen mikäli salasana ja sähköposti olivat oikein. |
+|    | **2** |   | 
 | yht   | **67**   | | 

--- a/tuntikirjanpito.md
+++ b/tuntikirjanpito.md
@@ -63,6 +63,7 @@
 |    | **6** |   | 
 |  16.8.  | 2.5 | Yritä tehdä testi joka katsoo kutsutaanko `getUserFromLocalStorage()` funktiota renderöitäessä.  | 
 |    | 3.5 | Onnistu luomaan [spyOn](https://v1.vitest.dev/api/vi#vi-spyon) funktio, joka katsoo että `getUserFromLocalStorage()` funktiota kutsutaan renderöitäessä  | 
-
-|    | **6** |   | 
-| yht   | **79**   | | 
+|    | **6** |   |
+|  19.8. | 1,5 | Tee workflow tiedosto renderöintitestejä varten ja testaile sen toimivuutta [Nektos act](https://nektosact.com/introduction.html):illa paikallisesti. Tee alustavat E2E-testit `/login` osoitteelle. |
+|    | **1,5** |   |
+| yht   | **80,5**   | | 

--- a/tuntikirjanpito.md
+++ b/tuntikirjanpito.md
@@ -61,4 +61,8 @@
 |    | 2 | Tee thunk funktio joka hakee tilan local storagesta ja siirtää tilan Redux storeen. Päivitä käyttäjän tilaan tarvittava interface `UserObject` ja tyyppi `UserState`. Refaktoroi `Login.tsx` käyttäjäntilan haku `useEffect()` hookilla. | 
 |    | 2 | Refaktoroi renderöintitestit, apufunktiot ja tee testit `Login.tsx`-routelle | 
 |    | **6** |   | 
-| yht   | **73**   | | 
+|  16.8.  | 2.5 | Yritä tehdä testi joka katsoo kutsutaanko `getUserFromLocalStorage()` funktiota renderöitäessä.  | 
+|    | 3.5 | Onnistu luomaan [spyOn](https://v1.vitest.dev/api/vi#vi-spyon) funktio, joka katsoo että `getUserFromLocalStorage()` funktiota kutsutaan renderöitäessä  | 
+
+|    | **6** |   | 
+| yht   | **79**   | | 

--- a/tuntikirjanpito.md
+++ b/tuntikirjanpito.md
@@ -59,5 +59,6 @@
 |    | **1**   | | 
 | 15.8. | 2 | Tee `ProtectedRoute.tsx` kirjautumattomien käyttäjien näkymän hallintaan. Säädä `Login.tsx` siirtämään käyttäjä omalle profiilisivulleen mikäli salasana ja sähköposti olivat oikein. |
 |    | 2 | Tee thunk funktio joka hakee tilan local storagesta ja siirtää tilan Redux storeen. Päivitä käyttäjän tilaan tarvittava interface `UserObject` ja tyyppi `UserState`. Refaktoroi `Login.tsx` käyttäjäntilan haku `useEffect()` hookilla. | 
-|    | **4** |   | 
-| yht   | **67**   | | 
+|    | 2 | Refaktoroi renderöintitestit, apufunktiot ja tee testit `Login.tsx`-routelle | 
+|    | **6** |   | 
+| yht   | **73**   | | 


### PR DESCRIPTION
# Login front

## Features

- Create a state in Redux store to control user's auth state when they log in in the application from the frontend
- Add `<ProtectedRoute />` component for controlling user's access to certain pages if they are unauthorized
- Add initial tests relating to login operations and rendering
- Add workflow file for running frontend rendering tests

### User state in Redux
- User's initial state is null
- If state is null when you navigate to `/login` or a `<ProtectedRoute />`, check the user's state from localStorage and copy it from there if exists.

### Update rendering tests and helpers
- Make initial test cases for checking that  `<Login />` renders correctly
- Rename and refactor `renderWithTheme` to `renderWithThemeAndProviders` to create virtual DOM now with Redux Provider and React Router